### PR TITLE
Fix address lookup in AAS pathfinder

### DIFF
--- a/aas_pathfinder.py
+++ b/aas_pathfinder.py
@@ -17,9 +17,9 @@ except Exception:  # pragma: no cover - geopy may not be installed
 
 
 def _find_address(elements):
-    """Recursively search for a Property with idShort 'Location' or 'Address'."""
+    """Recursively search for a Property with an address idShort."""
     for elem in elements:
-        if elem.get("idShort") in {"Location", "Address"}:
+        if elem.get("idShort") in {"Location", "Address", "Physical_address"}:
             val = elem.get("value")
             if isinstance(val, str):
                 return val


### PR DESCRIPTION
## Summary
- support `Physical_address` entries when loading AAS JSON files

## Testing
- `python -m py_compile aas_pathfinder.py`
- `python aas_pathfinder.py --aas-dir '설비 json 파일' | head` *(fails: Not enough AAS locations found because geopy isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68767f4928c48323b1550abed0ef61c5