### PR TITLE
Refactor converter to use BaSyx SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ This approach is more reliable than depending on IRDI codes.
 
 ## Converting legacy AAS files
 
-`convert_to_aas.py` converts the irregular JSON files found in `설비 json 파일/` to a simplified structure that matches the normalised AAS layout.  Run the script with the input and output directories:
+`convert_to_aas.py` converts the irregular JSON files found in `설비 json 파일/` to a simplified structure that matches the normalised AAS layout.  The tool relies on `basyx-python-sdk` to write the JSON output, so install the package first.
 
 ```bash
+pip install basyx-python-sdk
 python convert_to_aas.py "설비 json 파일" converted
 ```
 


### PR DESCRIPTION
## Summary
- integrate basyx-python-sdk into `convert_to_aas.py`
- update README with new usage instructions

## Testing
- `python -m py_compile aas_pathfinder.py export_aasx.py convert_to_aas.py astar_demo.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687906d795c4832386086f25c45a926c