### PR TITLE
Fix identifier creation for multiple SDK versions

### DIFF
--- a/convert_to_aas.py
+++ b/convert_to_aas.py
@@ -53,10 +53,18 @@ def _ident(data: Dict[str, Any]) -> Any:
 
     if aas is None:  # pragma: no cover - handled in _require_sdk
         return None
-    return aas.Identifier(
-        id=data.get("id", ""),
-        id_type=data.get("idType", "Custom"),
-    )
+    ident = data.get("id", "")
+    id_type = data.get("idType", "Custom")
+    try:
+        # Older versions of the SDK accept keyword arguments
+        return aas.Identifier(id=ident, id_type=id_type)
+    except TypeError:
+        try:
+            # Newer releases might require positional arguments
+            return aas.Identifier(ident, id_type)
+        except TypeError:
+            # Fallback for versions where ``Identifier`` is an alias of ``str``
+            return aas.Identifier(ident)
 
 
 def _prop(id_short: str, value: Any, value_type: str = "string") -> Any:


### PR DESCRIPTION
## Summary
- handle different `Identifier` constructors in `convert_to_aas.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879249738248323adbdc6db7d750e6d