### PR TITLE
Improve Identifier handling

### DIFF
--- a/convert_to_aas.py
+++ b/convert_to_aas.py
@@ -64,7 +64,15 @@ def _ident(data: Any, fallback_id: str = "http://example.com/dummy-id") -> Any:
     ident = ident.replace(" ", "_")
     if not ident:
         ident = fallback_id
-    return aas.Identifier(id=ident, id_type=id_type)
+    try:
+        return aas.Identifier(id=ident, id_type=id_type)
+    except TypeError:
+        # Identifier might be a simple string alias or support a
+        # different constructor.  Fallback to the most permissive option.
+        try:
+            return aas.Identifier(ident)
+        except Exception:
+            return ident
 
 
 def _create(cls: Any, /, *args: Any, **kwargs: Any) -> Any:
@@ -85,7 +93,10 @@ def _create(cls: Any, /, *args: Any, **kwargs: Any) -> Any:
     # ident 보정
     if ident is not None and not hasattr(ident, "id"):
         print(f"WARNING: ident is not Identifier, got {type(ident)}: {ident!r}. Wrapping as Identifier.")
-        ident = aas.Identifier(id=str(ident), id_type="Custom")
+        try:
+            ident = aas.Identifier(id=str(ident), id_type="Custom")
+        except TypeError:
+            ident = str(ident)
 
     id_value = kwargs.pop("id_", None)
     if hasattr(ident, "id"):

--- a/tests/test_convert_to_aas.py
+++ b/tests/test_convert_to_aas.py
@@ -1,0 +1,44 @@
+import types
+import importlib
+
+import convert_to_aas
+
+class Dummy:
+    def __init__(self, id=None, identification=None, id_short=None):
+        self.id = id
+        self.identification = identification
+        self.id_short = id_short
+
+def make_fake_aas(identifier):
+    fake = types.SimpleNamespace()
+    fake.Identifier = identifier
+    return fake
+
+def test_ident_class(monkeypatch):
+    class Identifier:
+        def __init__(self, id, id_type):
+            self.id = id
+            self.id_type = id_type
+    fake_aas = make_fake_aas(Identifier)
+    monkeypatch.setattr(convert_to_aas, "aas", fake_aas)
+
+    ident = convert_to_aas._ident("foo")
+    assert isinstance(ident, Identifier)
+    assert ident.id == "foo"
+    assert ident.id_type == "Custom"
+
+    obj = convert_to_aas._create(Dummy, id_short="x", identification=ident)
+    assert isinstance(obj, Dummy)
+    assert obj.identification is ident
+
+
+def test_ident_str_alias(monkeypatch):
+    fake_aas = make_fake_aas(str)
+    monkeypatch.setattr(convert_to_aas, "aas", fake_aas)
+
+    ident = convert_to_aas._ident("bar")
+    assert ident == "bar"
+
+    obj = convert_to_aas._create(Dummy, id_short="x", identification=ident)
+    assert isinstance(obj, Dummy)
+    assert obj.identification == "bar"


### PR DESCRIPTION
## Summary
- support basyx SDKs where `Identifier` is `str`
- adjust `_create` to gracefully handle string identifiers
- add unit tests covering both Identifier implementations

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879367507308323a1e8342d2d171eac