### PR TITLE
Fix local SDK usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ notebook `A star algorithm.ipynb` has been replaced by `astar_demo.py` which is
 fully runnable from the command line.
 
 ``astar_demo.py`` optionally loads Asset Administration Shell (AAS) JSON files
-from the given directory when the `basyx-python-sdk` is installed.  The loaded
+from the given directory when the bundled BaSyx SDK is available. The loaded
 AAS `idShort` values and their submodel names are printed before running the
 search.
 
@@ -32,10 +32,9 @@ This approach is more reliable than depending on IRDI codes.
 
 ## Converting legacy AAS files
 
-`convert_to_aas.py` converts the irregular JSON files found in `설비 json 파일/` to a simplified structure that matches the normalised AAS layout.  The tool relies on `basyx-python-sdk` to write the JSON output, so install the package first.
+`convert_to_aas.py` converts the irregular JSON files found in `설비 json 파일/` to a simplified structure that matches the normalised AAS layout.  The tool relies on the BaSyx SDK bundled in the `sdk/` directory to write the JSON output.
 
 ```bash
-pip install basyx-python-sdk
 python convert_to_aas.py "설비 json 파일" converted
 ```
 
@@ -47,15 +46,8 @@ name, so each converted file receives deterministic IDs without manual edits.
 
 ## Building AAS with BaSyx
 
-`export_aasx.py` demonstrates how to load the normalised JSON files
+`export_aasx.py` (not included here) demonstrates how to load the normalised JSON files
 produced by `convert_to_aas.py` and export them as an `.aasx` package using the
-`basyx-python-sdk`.
-
-Install the SDK and run the tool:
-
-```bash
-pip install basyx-python-sdk
-python export_aasx.py converted/example.json example.aasx
-```
+bundled BaSyx SDK.
 
 The resulting `example.aasx` can be opened in any compliant AAS tool.

--- a/astar_demo.py
+++ b/astar_demo.py
@@ -2,20 +2,26 @@
 
 This script replicates the functionality that originally lived in the notebook
 ``A star algorithm.ipynb``.  It optionally loads Asset Administration Shell (AAS)
-JSON files using ``basyx-python-sdk`` and then performs an A* search on a small
-demo graph.  The found path is displayed both textually and in a simple ASCII
-grid so the result can be visualised without additional libraries.
+JSON files using the BaSyx SDK bundled in ``sdk/`` and then performs an A* search
+on a small demo graph.  The found path is displayed both textually and in a
+simple ASCII grid so the result can be visualised without additional libraries.
 """
 
 import argparse
 import os
+import sys
 from contextlib import redirect_stdout, redirect_stderr
 from io import StringIO
 
 from graph import Graph, Node
 from a_star import AStar
 
-# ``basyx-python-sdk`` is optional.  If it is missing the script will still run
+# Use the local SDK if available
+SDK_DIR = os.path.join(os.path.dirname(__file__), "sdk")
+if SDK_DIR not in sys.path:
+    sys.path.insert(0, SDK_DIR)
+
+# BaSyx SDK is optional. If it is missing the script will still run
 try:
     from basyx.aas.adapter.json import read_aas_json_file
 except ImportError:  # basyx library might not be available


### PR DESCRIPTION
## Summary
- use bundled BaSyx SDK only
- fix ModelReference usage when converting
- adjust demo to add local SDK path
- clarify README about bundled SDK

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyecma376_2')*

------
https://chatgpt.com/codex/tasks/task_e_68795941ab3c83238fd5d9ad5fb86af4