### PR TITLE
Fix main entry point docstring

### DIFF
--- a/aas_pathfinder.py
+++ b/aas_pathfinder.py
@@ -280,7 +280,8 @@ def dijkstra_path(graph: Graph, start: str, goal: str) -> Tuple[List[str], float
     return path, dist[goal]
 
 
-def main():
+def main() -> None:
+    """Entry point used when running this module as a script."""
     parser = argparse.ArgumentParser(description="AAS path finder")
     parser.add_argument(
         "--aas-dir",


### PR DESCRIPTION
## Summary
- add docstring and return type to main() in `aas_pathfinder.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyecma376_2')*

------
https://chatgpt.com/codex/tasks/task_e_687a4c7ed8388323a59c32ff02e04fbb